### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ VPBiometricAuthenticationFacade is a high level wrapper for [LocalAuthentication
 Full description of project is available [here (RUS)](http://habrahabr.ru/post/235699/)
 
 ### Installation
-##### Cocoa Pods
+##### CocoaPods
 Add to your Podfile ```pod "BiometricAuthenticationFacade"```.
 ##### Drag&Drop
 1. Drag and drop BiometricAuthenticationFacade.xcodeproj to your project;


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
